### PR TITLE
Add matmul Op

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ enum class GraphType {
   ConvBiasLeakyRelu = 6,
   ConvBn = 7,
 
-  MatMulBiasTanh = 100,
-  MatMulBiasSigmoid = 101,
-  MatMulBiasGeluExact = 102
+  MatMul = 100,
+  MatMulBiasTanh = 102,
+  MatMulBiasSigmoid = 103,
+  MatMulBiasGeluExact = 104
 
   AvgPoolFwd = 200,
   AvgPoolBwd = 201,

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ enum class GraphType {
   ConvBn = 7,
 
   MatMul = 100,
-  MatMulBiasTanh = 102,
-  MatMulBiasSigmoid = 103,
-  MatMulBiasGeluExact = 104
+  MatMulBiasTanh = 101,
+  MatMulBiasSigmoid = 102,
+  MatMulBiasGeluExact = 103,
 
   AvgPoolFwd = 200,
   AvgPoolBwd = 201,

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Execution time(ms): 0.288051
 Similarly, the following example shows a matmul graph of
 `MatMul-Bias-GeluExact`.
 ```
-$ ./run_matmul_graphs.out -a 1,8,16 -b 1,16,32 -bias 1,1,32 -data_type 1 -data_format 1 -engine_index 4 -graph_index 102
+$ ./run_matmul_graphs.out -a 1,8,16 -b 1,16,32 -bias 1,1,32 -data_type 1 -data_format 1 -engine_index 4 -graph_index 103
 >>> Retrieved MatMul specs:
 >>>   num_dims: 3,
 >>>   a_dims (-a): 1, 8, 16,
@@ -106,7 +106,7 @@ $ ./run_matmul_graphs.out -a 1,8,16 -b 1,16,32 -bias 1,1,32 -data_type 1 -data_f
 >>>   transpose_b (-transpose_b): 0,
 >>>   data_type (-data_type [0<fp32>|1<fp16>]): 1,
 >>>   engine_index (-engine_index): 4,
->>>   graph_index (-graph_index <int>(+100 for matmul graphs)): 102
+>>>   graph_index (-graph_index <int>(+100 for matmul graphs)): 103
 >>>   graph_name: MatMulBiasGeluExactGraph
 ...
 Using (4): Matmul_Add_GeluFwd_eng0_k24=5

--- a/samples/run_matmul_graphs.cc
+++ b/samples/run_matmul_graphs.cc
@@ -68,6 +68,12 @@ int main(int argc, char** argv) {
 
   auto graph_type = static_cast<GraphType>(graph_index);
   switch (graph_type) {
+    case GraphType::MatMul: {
+      int64_t uids[] = {'a', 'b', 'c'};
+      auto launcher = LaunchOpRunner<void*, void*, void*>();
+      launcher(cudnn, plan_desc, workspace_ptr, uids, a_ptr, b_ptr, c_ptr);
+      break;
+    }
     case GraphType::MatMulBiasTanh:
     case GraphType::MatMulBiasSigmoid:
     case GraphType::MatMulBiasGeluExact: {

--- a/src/graph_builder.h
+++ b/src/graph_builder.h
@@ -18,9 +18,10 @@ enum class GraphType {
   ConvBiasLeakyRelu = 6,
   ConvBn = 7,
 
-  MatMulBiasTanh = 100,
-  MatMulBiasSigmoid = 101,
-  MatMulBiasGeluExact = 102,
+  MatMul = 100,
+  MatMulBiasTanh = 101,
+  MatMulBiasSigmoid = 102,
+  MatMulBiasGeluExact = 103,
 
   AvgPoolFwd = 200,
   AvgPoolBwd = 201,


### PR DESCRIPTION
https://github.com/kaixih/cudnn_frontend_test/issues/2
Add pure matmul operation. Test in V100 cuda-11.6-cudnn-8.8.1.3
```
  MatMul = 100,
  MatMulBiasTanh = 102,
  MatMulBiasSigmoid = 103,
  MatMulBiasGeluExact = 104
```

m=2w, k=w, n=w

```
for i in {1..16}; do
	w=$((i * 192))
	ww=$((w * 2))
	cmd_1="./run_matmul_graphs.out -a 1,$ww,$w -b 1,$w,$w -data_type 1 -data_format 1 -engine_index 0 -graph_index 100"
	$cmd_1
done
```
logs: https://gist.github.com/Adnios/fdb0a58158d43f172f346536348a2fea

| m    | n    | k    | Execution Time (ms) |
|------|------|------|---------------------|
| 384  | 192  | 192  | 0.009459            |
| 768  | 384  | 384  | 0.01327             |
| 1152 | 576  | 576  | 0.026022            |
| 1536 | 768  | 768  | 0.033955            |
| 1920 | 960  | 960  | 0.060323            |
| 2304 | 1152 | 1152 | 0.111155            |
| 2688 | 1344 | 1344 | 0.165645            |
| 3072 | 1536 | 1536 | 0.192214            |
| 3456 | 1728 | 1728 | 0.315418            |
| 3840 | 1920 | 1920 | 0.354534            |
| 4224 | 2112 | 2112 | 0.490998            |
| 4608 | 2304 | 2304 | 0.681677            |
| 4992 | 2496 | 2496 | 0.74072             |
| 5376 | 2688 | 2688 | 0.947011            |
| 5760 | 2880 | 2880 | 1.214205            |
| 6144 | 3072 | 3072 | 1.451402            |
